### PR TITLE
BitStreamArcLabelledImmutableGraph: add memory-mapped loading methods

### DIFF
--- a/src/it/unimi/dsi/big/webgraph/labelling/BitStreamArcLabelledImmutableGraph.java
+++ b/src/it/unimi/dsi/big/webgraph/labelling/BitStreamArcLabelledImmutableGraph.java
@@ -263,6 +263,14 @@ public class BitStreamArcLabelledImmutableGraph extends ArcLabelledImmutableGrap
 		return load(LoadMethod.OFFLINE, basename, pl);
 	}
 
+	public static BitStreamArcLabelledImmutableGraph loadMapped(final CharSequence basename) throws IOException {
+		return load(LoadMethod.MAPPED, basename, null);
+	}
+
+	public static BitStreamArcLabelledImmutableGraph loadMapped(final CharSequence basename, final ProgressLogger pl) throws IOException {
+		return load(LoadMethod.MAPPED, basename, pl);
+	}
+
 	public static BitStreamArcLabelledImmutableGraph load(final CharSequence basename) throws IOException {
 		return load(LoadMethod.STANDARD, basename, null);
 	}


### PR DESCRIPTION
Before this commit, calling `loadMapped()` on a
BitStreamArcLabelledImmutableGraph would trigger an infinite loop, as it
would call the parent method `ImmutableGraph.loadMapped()` that was never
overriden.